### PR TITLE
adding yaml ESPHome YAML for Siemens WM14Q441

### DIFF
--- a/contrib/bsh-dbus-wm14q441.yaml
+++ b/contrib/bsh-dbus-wm14q441.yaml
@@ -1,6 +1,7 @@
 #
-# bsh-dbus-wm14s750.yaml -- Interface B/S/H/ washing machine WM14S750
+# bsh-dbus-wm14q441.yaml -- Interface B/S/H/ washing machine WM14Q441
 #
+# (C) 2025 fkzle
 # (C) 2024 Hajo Noerenberg
 #
 # Usage: Connect D-Bus DATA pin to pin D5


### PR DESCRIPTION
Adding of the washing machine Siemens 14Q441 which was built around 2012. 
The mainboard identifier is EPW65923.

The DBUS-connector can be found here: 
![20251229_183639_1](https://github.com/user-attachments/assets/2e0cc343-6813-40b6-bedb-d5596469561c)
