### PR TITLE
Add bsh-dbus-wm14e3a0.yaml config file

### DIFF
--- a/contrib/bsh-dbus-wm14e3a0.yaml
+++ b/contrib/bsh-dbus-wm14e3a0.yaml
@@ -1,0 +1,220 @@
+#
+# bsh-dbus-wm14e3a0.yaml -- Interface B/S/H/ washing machine WM14E3A0
+#
+# (C) 2024-2025 Hajo Noerenberg
+# (C) 2026 Bouni
+#
+# Usage: Config (pinout) for Bouni's board: https://github.com/Bouni/BSH-Board
+#
+# http://www.noerenberg.de/
+# https://github.com/hn/bsh-home-appliances
+#
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3.0 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.txt>.
+#
+
+esphome:
+  name: bsh-dbus-wm14e3a0 
+  friendly_name: BSH washing machine WM14E3A0
+
+external_components:
+  - source: github://hn/bsh-home-appliances@master
+
+esp32:
+  board: esp32-c6-devkitc-1
+  variant: esp32c6
+  framework:
+    type: esp-idf
+
+logger:
+
+api:
+  encryption:
+    key: !secret api_encryption_key
+
+ota:
+  - platform: esphome
+    password: !secret ota_password
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  # Dirty workaround if the machine's power supply unit cannot provide enough current:
+  # output_power: 10.5dB
+
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: "D-Bus Fallback Hotspot"
+    password: !secret wifi_ap_password
+
+captive_portal:
+
+status_led:
+  pin:
+    number: GPIO6
+    inverted: true
+
+output:
+  - platform: gpio
+    pin:
+      number: GPIO7
+      inverted: true
+    id: activity_led
+
+uart:
+  id: dbus_uart
+  rx_pin: GPIO4
+  tx_pin: GPIO5
+  baud_rate: 9600
+
+bshdbus:
+  uart_id: dbus_uart
+
+binary_sensor:
+  - platform: bshdbus
+    dest: 0x22
+    command: 0x1003
+    binary_sensors:
+      - id: bsh_wm_feat_stains
+        name: Flecken
+        icon: mdi:leaf
+        lambda: return x[6] & 0x01;
+
+      - id: bsh_wm_feat_pre_wash
+        name: Vorwäsche
+        icon: mdi:rotate-orbit
+        lambda: return x[6] & 0x02;
+
+      - id: bsh_wm_feat_anti_crease
+        name: Knitterschutz
+        icon: mdi:iron
+        lambda: return x[6] & 0x04;
+
+      - id: bsh_wm_feat_waterplus
+        name: Extraspühlen
+        icon: mdi:water-plus
+        lambda: return x[6] & 0x08;
+
+sensor:
+  - platform: bshdbus
+    dest: 0x22
+    command: 0x1003
+    sensors:
+      - id: bsh_wm_start_led
+        lambda: |-
+          return (x[6] & 0x10) ? 1 : 0;
+        filters:
+          - debounce: 2s
+          # We should always get a new update each minute if we're running
+          # if we don't have one after 120 seconds, mark the machine as Off
+          - timeout:
+              timeout: 120s
+              value: 0
+
+      - id: bsh_wm_remain
+        name: Restlaufzeit
+        device_class: duration
+        state_class: measurement
+        unit_of_measurement: min
+        accuracy_decimals: 0
+        lambda: |-
+          unsigned int r = 0;
+          for (unsigned int i = 3; i <= 5; i++) {
+            const unsigned int m[] = {60, 10, 1};
+            switch (x[i]) {
+              // Each bit corresponds to one single LED
+              // in a 7-segment digit like this:
+              //
+              //   EEE
+              //  G   B
+              //   DDD
+              //  F   A
+              //   CCC
+              //
+              //      ABCDEFG
+              case 0b01110111: r += 0 * m[i-3]; break;
+              case 0b01100000: r += 1 * m[i-3]; break;
+              case 0b00111110: r += 2 * m[i-3]; break;
+              case 0b01111100: r += 3 * m[i-3]; break;
+              case 0b01101001: r += 4 * m[i-3]; break;
+              case 0b01011101: r += 5 * m[i-3]; break;
+              case 0b01011111: r += 6 * m[i-3]; break;
+              case 0b01100100: r += 7 * m[i-3]; break;
+              case 0b01111111: r += 8 * m[i-3]; break;
+              case 0b01111101: r += 9 * m[i-3]; break;
+            }
+          }
+          return r;
+      - id: bsh_wm_temperature
+        name: Temperatur
+        device_class: temperature
+        state_class: measurement
+        unit_of_measurement: °C
+        accuracy_decimals: 0
+        lambda: |-
+            switch (x[0] >> 1) {
+              case 0x20: return 0;
+              case 0x10: return 30;
+              case 0x8:  return 40;
+              case 0x4:  return 50;
+              case 0x2:  return 60;
+              case 0x1:  return 90;
+            }
+            return NAN;
+      - id: bsh_wm_rpm
+        name: Drehzahl
+        device_class: speed
+        state_class: measurement
+        unit_of_measurement: rpm
+        accuracy_decimals: 0
+        lambda: |-
+            switch (x[1]) {
+              case 0x40: return 0;
+              case 0x20: return 400;
+              case 0x10: return 600;
+              case 0x8:  return 800;
+              case 0x6:  return 1200;
+              case 0x1:  return 1400;
+            }
+            return NAN;
+
+text_sensor:
+  - platform: template
+    id: bsh_wm_status
+    name: Status
+    lambda: |-
+      if (id(bsh_wm_start_led).state == 1) {
+        if (id(bsh_wm_remain).state < 1) {
+          return { "Fertig" };
+        }
+
+        return { "Läuft" };
+      } else {
+        return { "Aus" };
+      }
+    update_interval: 5s
+
+  - platform: bshdbus
+    dest: 0x22
+    command: 0x1003
+    text_sensors:
+      - id: bsh_wm_program_status
+        name: Programm status
+        entity_category: diagnostic
+        icon: mdi:map-marker-path
+        lambda: |-
+            if (x[2] & 0x8) { return { "Schleudern" }; }
+            if (x[2] & 0x4) { return { "Spühlen" }; }
+            if (x[2] & 0x2) { return { "Waschen" }; }
+
+            return { "Aus" };


### PR DESCRIPTION
This adds the config for the Siemens washing machine WM14E3A0.

Its based on https://github.com/Bouni/bsh-home-appliances/blob/b78ad7c749e6d5f81f028fef999ec47a2a9dd03a/contrib/bsh-dbus-wae284f0nl.yaml

The only changes are for the used board (https://github.com/Bouni/BSH-Board) and the texts are translated to german.