### PR TITLE
docs: recommend ESPHome 2026.1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,9 @@ It uses an [external component](https://esphome.io/components/external_component
 called [bshdbus](components/bshdbus/). There is no documentation (yet) but
 you'll quickly get the idea on how to add your own sensors.
 
+> [!IMPORTANT]
+> Recommended ESPHome version is **2026.1 or newer**.
+
 #### Other home appliance models
 
 Fortunately, people have started to create configuration files for devices they own.


### PR DESCRIPTION
## Summary
- recommend ESPHome 2026.1 or newer in README

## Why
- I ran into complex, not very helpful error messages with ESPHome 2025.8
- this note should save others time when troubleshooting similar issues

## Scope
- documentation only (README)