### PR TITLE
Fix ESP_LOGV with empty argument

### DIFF
--- a/components/bshdbus/bshdbus.cpp
+++ b/components/bshdbus/bshdbus.cpp
@@ -83,7 +83,7 @@ void BSHDBus::loop() {
         this->expect_ack_ = false;
         if (((buf[i] & 0x0F) == 0x0A) &&
             ((this->last_dest_ & 0xF0) ? ((buf[i] & 0xF0) == (this->last_dest_ & 0xF0)) : (buf[i] & 0xF0))) {
-          ESP_LOGV(TAG, "Received valid ACK 0x%02x for dest 0x%02x of preceding frame", buf[i], , this->last_dest_);
+          ESP_LOGV(TAG, "Received valid ACK 0x%02x for dest 0x%02x of preceding frame", buf[i], this->last_dest_);
           i++;
           continue;
         } else {


### PR DESCRIPTION
Fix compiler error:

```
src/esphome/components/bshdbus/bshdbus.cpp:86:97: error: expected primary-expression before ',' token
   86 |           ESP_LOGV(TAG, "Received valid ACK 0x%02x for dest 0x%02x of preceding frame", buf[i], , this->last_dest_);
```

